### PR TITLE
Pre-install npm packages on get-started page

### DIFF
--- a/i18n/ja/docusaurus-plugin-content-pages/get-started.mdx
+++ b/i18n/ja/docusaurus-plugin-content-pages/get-started.mdx
@@ -42,6 +42,7 @@ NFT は[特別なメタデータ](api/metadata)の URI を保持することが�
 
 ```bash
 cp .env.sample .env # and rewrite API Keys
+yarn # install the required packages
 yarn store-metadata # and you will publish metadata with hokusai.png
 ```
 

--- a/src/pages/get-started.mdx
+++ b/src/pages/get-started.mdx
@@ -40,6 +40,7 @@ Run the code below.
 
 ```bash
 cp .env.sample .env # and rewrite API Keys
+yarn # install the required packages
 yarn store-metadata # and you will publish metadata with hokusai.png
 ```
 


### PR DESCRIPTION
## Related issue

close #xx

## Changes

Get Startedページの`3. Publish NFT metadata`セクションにある`yarn store-metadata`コマンドを実行する前に`yarn`コマンドでパッケージをインストールするようにしました。

- https://docs.hokusai.app/get-started#3-publish-nft-metadata

## What not to do

## Check instructions

## Others

初回時にyarnコマンドを実行してパッケージをインストールしないと以下のように動作しません。

```
$ yarn store-metadata
yarn run v1.22.11
$ run-s tsc store-metadata:run
/bin/sh: 1: run-s: not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```